### PR TITLE
Add test for resource path escape characters in observability data

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinai"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/observe-internal-native-1.0.4.jar"
+path = "../native/build/libs/observe-internal-native-1.0.5-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinai"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/observe-internal-native-1.0.5-SNAPSHOT.jar"
+path = "../native/build/libs/observe-internal-native-1.0.6-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -17,7 +17,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.caching=true
 group=io.ballerina
 version=1.0.5-SNAPSHOT
 
-ballerinaLangVersion=2201.0.4
+ballerinaLangVersion=2201.4.0-20221212-011800-9715f15d
 ballerinaTomlParserVersion=1.2.2
 ballerinaGradlePluginVersion=0.14.2
 puppycrawlCheckstyleVersion=8.18

--- a/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
+++ b/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
@@ -405,7 +405,6 @@ public class MetricsTestCase extends ObservabilityBaseTest {
         );
     }
 
-    @Test(enabled = false)
     public void testPathsWithEscapeCharacters() throws Exception {
         String fileName = "02_resource_function.bal";
         String serviceName = "/this\\-is\\-service\\-path/still\\-service\\-path";

--- a/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
+++ b/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
@@ -405,6 +405,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
         );
     }
 
+    @Test
     public void testPathsWithEscapeCharacters() throws Exception {
         String fileName = "02_resource_function.bal";
         String serviceName = "/this\\-is\\-service\\-path/still\\-service\\-path";

--- a/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
+++ b/integration-tests/src/test/java/io/ballerina/stdlib/observability/metrics/MetricsTestCase.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.observability.metrics;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import io.ballerina.identifier.Utils;
 import io.ballerina.runtime.observability.metrics.PercentileValue;
 import io.ballerina.runtime.observability.metrics.Snapshot;
 import io.ballerina.runtime.observability.metrics.Tag;
@@ -78,7 +79,7 @@ public class MetricsTestCase extends ObservabilityBaseTest {
 
     @BeforeClass(alwaysRun = true)
     public void setup() throws Exception {
-        super.setupServer(TEST_SRC_PROJECT_NAME, TEST_SRC_PACKAGE_NAME, new int[]{10090, 10091, 10092});
+        super.setupServer(TEST_SRC_PROJECT_NAME, TEST_SRC_PACKAGE_NAME, new int[]{10090, 10091, 10092, 10093});
     }
 
     @AfterClass(alwaysRun = true)
@@ -401,6 +402,41 @@ public class MetricsTestCase extends ObservabilityBaseTest {
                 Tag.of(ENTRYPOINT_FUNCTION_NAME, resourceName),
                 Tag.of(ENTRYPOINT_RESOURCE_ACCESSOR, "post"),
                 Tag.of(ENTRYPOINT_SERVICE_NAME, serviceName)
+        );
+    }
+
+    @Test(enabled = false)
+    public void testPathsWithEscapeCharacters() throws Exception {
+        String fileName = "02_resource_function.bal";
+        String serviceName = "/this\\-is\\-service\\-path/still\\-service\\-path";
+        String resourceName = "/this\\-is\\-resource\\-function/still\\-resource\\-function";
+        String serviceNameUnescaped = "/this-is-service-path/still-service-path";
+        String resourceNameUnescaped = "/this-is-resource-function/still-resource-function";
+        if (!serviceNameUnescaped.equals(Utils.unescapeBallerina(serviceNameUnescaped)) ||
+                !resourceNameUnescaped.equals(Utils.unescapeBallerina(resourceNameUnescaped))) {
+            throw new AssertionError("Unescaped path is not correct");
+        }
+
+        HttpResponse httpResponse = HttpClientRequest.doPost("http://localhost:10093" + serviceName +
+                resourceName, "15", Collections.emptyMap());
+        Assert.assertEquals(httpResponse.getResponseCode(), 200);
+        Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
+        Thread.sleep(1000);
+
+        Metrics metrics = this.getMetrics();
+        testFunctionMetrics(metrics, fileName + ":83:5", 1,
+                Tag.of(SRC_SERVICE_RESOURCE, "true"),
+                Tag.of(SRC_OBJECT_NAME, serviceNameUnescaped),
+                Tag.of(PROTOCOL, "http"),
+                Tag.of(HTTP_URL, serviceName + resourceName),
+                Tag.of(ENTRYPOINT_FUNCTION_MODULE, MODULE_ID),
+                Tag.of(SRC_RESOURCE_ACCESSOR, "post"),
+                Tag.of(ENTRYPOINT_RESOURCE_ACCESSOR, "post"),
+                Tag.of(ENTRYPOINT_SERVICE_NAME, serviceNameUnescaped),
+                Tag.of(ENTRYPOINT_FUNCTION_NAME, resourceNameUnescaped),
+                Tag.of(LISTENER_NAME, "testobserve_listener"),
+                Tag.of(SRC_RESOURCE_PATH, resourceNameUnescaped),
+                Tag.of(HTTP_METHOD , "POST")
         );
     }
 

--- a/integration-tests/src/test/resources/observability/metrics_tests/02_resource_function.bal
+++ b/integration-tests/src/test/resources/observability/metrics_tests/02_resource_function.bal
@@ -78,3 +78,9 @@ function testWorkerInteractions(int c) {
     wait w2;
     wait w1;
 }
+
+service /this\-is\-service\-path/still\-service\-path on new testobserve:Listener(10093) {
+    resource function post this\-is\-resource\-function/still\-resource\-function(testobserve:Caller caller) {
+        checkpanic caller->respond("Invocation Successful");
+    }
+}

--- a/integration-tests/src/test/resources/observability/metrics_tests/Dependencies.toml
+++ b/integration-tests/src/test/resources/observability/metrics_tests/Dependencies.toml
@@ -14,7 +14,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.1"
+version = "1.0.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/integration-tests/src/test/resources/observability/metrics_tests/Dependencies.toml
+++ b/integration-tests/src/test/resources/observability/metrics_tests/Dependencies.toml
@@ -14,7 +14,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/integration-tests/src/test/resources/observability/tracing_tests/Dependencies.toml
+++ b/integration-tests/src/test/resources/observability/tracing_tests/Dependencies.toml
@@ -14,7 +14,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/testobserve/ballerina/Ballerina.toml
+++ b/testobserve/ballerina/Ballerina.toml
@@ -4,4 +4,4 @@ name = "testobserve"
 version = "0.0.0"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/testobserve-native-1.0.4-SNAPSHOT-all.jar"
+path = "../native/build/libs/testobserve-native-1.0.5-SNAPSHOT-all.jar"

--- a/testobserve/ballerina/Ballerina.toml
+++ b/testobserve/ballerina/Ballerina.toml
@@ -4,4 +4,4 @@ name = "testobserve"
 version = "0.0.0"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/testobserve-native-1.0.5-SNAPSHOT-all.jar"
+path = "../native/build/libs/testobserve-native-1.0.6-SNAPSHOT-all.jar"


### PR DESCRIPTION
## Purpose
$title
Adding tests for ballerina-lang change https://github.com/ballerina-platform/ballerina-lang/pull/38213

## Remarks
Merge after changing the ballerina-lang version and enabling the test.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests