### PR TITLE
Fix conversion to sealed class in Java 17

### DIFF
--- a/integration-tests/src/test/java/io/ballerina/stdlib/observability/ObservabilityBaseTest.java
+++ b/integration-tests/src/test/java/io/ballerina/stdlib/observability/ObservabilityBaseTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.context.BallerinaTestException;
 import org.ballerinalang.test.context.Utils;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -58,7 +59,8 @@ public class ObservabilityBaseTest extends BaseTest {
         // Don't use 9898 port here. It is used in metrics test cases.
         servicesServerInstance = new BServerInstance(balServer);
         servicesServerInstance.startServer(sourcesDir, packageName, null, null, env, requiredPorts);
-        Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, "localhost");
+        InetAddress address = InetAddress.getByName("localhost");
+        Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, address);
     }
 
     protected void cleanupServer() throws BallerinaTestException, IOException {


### PR DESCRIPTION
## Purpose
Java 17 migration
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests