### PR TITLE
Update netty version to 4.1.135.Final

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,11 +1,11 @@
 [package]
 org = "ballerinai"
 name = "observe"
-version = "1.7.1"
+version = "1.7.2"
 distribution = "2201.13.2"
 
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
-path = "../native/build/libs/observe-internal-native-1.7.1.jar"
+path = "../native/build/libs/observe-internal-native-1.7.2-SNAPSHOT.jar"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ ballerinaTomlParserVersion=1.2.2
 ballerinaGradlePluginVersion=2.3.0
 checkstylePluginVersion=10.12.0
 openTelemetryVersion=1.7.0
-nettyCodecVersion=4.1.118.Final
+nettyCodecVersion=4.1.135.Final
 gsonVersion=2.10.1
 
 observeVersion=1.7.1

--- a/testobserve/ballerina/Ballerina.toml
+++ b/testobserve/ballerina/Ballerina.toml
@@ -4,4 +4,4 @@ name = "testobserve"
 version = "0.0.0"
 
 [[platform.java21.dependency]]
-path = "../native/build/libs/testobserve-native-1.7.0-SNAPSHOT-all.jar"
+path = "../native/build/libs/testobserve-native-1.7.2-SNAPSHOT-all.jar"

--- a/testobserve/ballerina/Dependencies.toml
+++ b/testobserve/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.13.2"
 
 [[package]]
 org = "ballerina"


### PR DESCRIPTION
## Summary

- Bumps `nettyCodecVersion` (`netty-codec-http`) from `4.1.118.Final` to `4.1.135.Final`

Netty 4.1.135.Final addresses security vulnerabilities including CVE-2026-47244 (HTTP/2 `SETTINGS_MAX_CONCURRENT_STREAMS` enforcement).

## Test plan
- [ ] CI passes with updated Netty version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the `nettyCodecVersion` dependency in `gradle.properties` from `4.1.118.Final` to `4.1.135.Final` to align the build with the latest Netty release and improve dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->